### PR TITLE
Rename 'encryptable' to 'encrypts'. Update documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ following additions/changes:
 
 * Do the encryption at the setAttribute/getAttributeFromArray layer rather than __set and
   __get as that's more appropriate for Laravel 5 with the new casts features.  So, for example,
-  you can add a field to $casts and also to $encryptable so that an array can be cast to a JSON
+  you can add a field to $casts and also to $encrypts so that an array can be cast to a JSON
   string first, and then encrypted.  It should also work for Lumen.
 
 * Prefix all encrypted values with a tag string (currently hard coded as `__ELOCRYPT__:` )
@@ -35,9 +35,27 @@ You must then run the following command:
 
 # Usage
 
-Simply reference the Elocrypt trait in any Eloquent Model you wish to apply encryption to and 
-then define an `$encryptable` array on that model containing a list of the attributes you wish
-to Encrypt.
+Simply reference the Elocrypt trait in any Eloquent Model you wish to apply encryption to and define an `$encrypts` array containing a list of the attributes to encrypt.
+
+For example:
+
+```php
+    use Delatbabel\Elocrypt\Elocrypt;
+
+    class User extends Eloquent {
+
+        use Elocrypt;
+       
+        /**
+         * The attributes that should be encrypted on save.
+         *
+         * @var array
+         */
+        protected $encrypts = ['first_name', 'last_name', 'address_line_1', 'postcode'];
+    }
+```
+
+You can combine `$casts` and `$encrypts` to store encrypted arrays.  An array will first be converted to JSON and then encrypted.
 
 For example:
 
@@ -48,23 +66,9 @@ For example:
 
         use Elocrypt;
 
-        public $encryptable = ['first_name', 'last_name', 'address_line_1', 'postcode'];
-    }
-```
+        protected $casts = ['extended_data' => 'array'];
 
-You can combine `$casts` and `$encryptable` to store encrypted arrays.  An array will first be
-converted to JSON and then encrypted.  For example:
-
-```php
-    use Delatbabel\Elocrypt\Elocrypt;
-
-    class User extends Eloquent {
-
-        use Elocrypt;
-
-        public $casts = ['extended_data' => 'array'];
-
-        public $encryptable = ['extended_data'];
+        protected $encrypts = ['extended_data'];
     }
 ```
 
@@ -72,7 +76,7 @@ converted to JSON and then encrypted.  For example:
 
 By including the Elocrypt trait, the setAttribute() and getAttributeFromArray() methods provided
 by Eloquent are overridden to include an additional step. This additional step simply checks
-whether the attribute being set or get is included in the "encryptable" array on the model,
+whether the attribute being set or get is included in the `$encrypts` array on the model,
 and either encrypts/decrypts it accordingly.
 
 ## Summary of Methods in Illuminate\Database\Eloquent\Model

--- a/src/Elocrypt.php
+++ b/src/Elocrypt.php
@@ -22,7 +22,7 @@ use Illuminate\Support\Facades\Crypt;
  *
  *       use Elocrypt;
  *
- *       public $encrypts = [
+ *       protected $encrypts = [
  *           'first_name',
  *           'last_name',
  *           'address_line_1',
@@ -89,7 +89,8 @@ trait Elocrypt
      */
     protected function encrypted($key, $value)
     {
-        // This string has not been prefixed so we assume it's not encrypted.
+        // This string has not been prefixed
+        // so we assume it's not encrypted.
         return $this->encryptable($key) && strpos($value, static::$ELOCRYPT_PREFIX) === 0;
     }
 
@@ -117,13 +118,8 @@ trait Elocrypt
     {
         if ( ! $this->encryptable($key)) return;
 
-        try {
-            // Prefix with a string so we know it's encrypted.
-            $this->attributes[$key] = static::$ELOCRYPT_PREFIX . Crypt::encrypt(
-                $this->attributes[$key]
-            );
-
-        } catch (EncryptException $e) {}
+        // Prefix so we can easily know it's encrypted.
+        $this->attributes[$key] = static::$ELOCRYPT_PREFIX . Crypt::encrypt($this->attributes[$key]);
     }
 
     /**
@@ -137,15 +133,8 @@ trait Elocrypt
     {
         if ( ! $this->encrypted($key, $value)) return $value;
 
-        try {
-            // Remove the prefix that we added when we encrypted it.
-            return Crypt::decrypt(
-                str_replace(static::$ELOCRYPT_PREFIX, '', $value)
-            );
-        }
-        catch (DecryptException $e) {}
-
-        return $value;
+        // Remove the prefix that we added when we encrypted it.
+        return Crypt::decrypt(str_replace(static::$ELOCRYPT_PREFIX, '', $value));
     }
 
     /**
@@ -170,22 +159,6 @@ trait Elocrypt
     }
 
     /**
-     * Map the decryption on an array of attributes
-     *
-     * @param  array $attributes
-     * @return array
-     */
-    protected function decryptAttributes($attributes)
-    {
-        // Decrypt them all as required
-        foreach ($attributes as $key => $value) {
-            $attributes[$key] = $this->decryptAttribute($key, $value);
-        }
-
-        return $attributes;
-    }
-
-    /**
      * Get all of the current attributes on the model.
      *
      * @return array
@@ -193,5 +166,21 @@ trait Elocrypt
     public function getAttributes()
     {
         return $this->decryptAttributes(parent::getAttributes());
+    }
+
+    /**
+     * Map the decryption on an array of attributes
+     *
+     * @param  array $attributes
+     * @return array
+     */
+    public function decryptAttributes($attributes)
+    {
+        // Decrypt them all as required
+        foreach ($attributes as $key => $value) {
+            $attributes[$key] = $this->decryptAttribute($key, $value);
+        }
+
+        return $attributes;
     }
 }

--- a/src/Elocrypt.php
+++ b/src/Elocrypt.php
@@ -63,9 +63,22 @@ use Illuminate\Support\Facades\Crypt;
  */
 trait Elocrypt
 {
+    /**
+     * The elocrypt prefix
+     *
+     * @var string
+     */
+    protected static $ELOCRYPT_PREFIX = '__ELOCRYPT__:';
 
-    protected function getElocryptPrefix() {
-        return '__ELOCRYPT__:';
+    /**
+     * Determine whether an attribute should be encrypted.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function encryptable($key)
+    {
+        return in_array($key, $this->encrypts);
     }
 
     /**
@@ -74,9 +87,10 @@ trait Elocrypt
      * @param  string  $key
      * @return bool
      */
-    protected function hasEncrypt($key)
+    protected function encrypted($key, $value)
     {
-        return in_array($key, $this->encrypts);
+        // This string has not been prefixed so we assume it's not encrypted.
+        return $this->encryptable($key) && strpos($value, static::$ELOCRYPT_PREFIX) === 0;
     }
 
     /**
@@ -88,74 +102,48 @@ trait Elocrypt
      */
     public function setAttribute($key, $value)
     {
-        // First we will check for the presence of a mutator for the set operation
-        // which simply lets the developers tweak the attribute as it is set on
-        // the model, such as "json_encoding" an listing of data for storage.
-        if ($this->hasSetMutator($key)) {
-            $method = 'set'.Str::studly($key).'Attribute';
+        parent::setAttribute($key, $value);
 
-            return $this->{$method}($value);
-        }
-
-        // If an attribute is listed as a "date", we'll convert it from a DateTime
-        // instance into a form proper for storage on the database tables using
-        // the connection grammar's date format. We will auto set the values.
-        elseif (in_array($key, $this->getDates()) && $value) {
-            $value = $this->fromDateTime($value);
-        }
-
-        if ($this->isJsonCastable($key) && ! is_null($value)) {
-            $value = json_encode($value);
-        }
-
-        // We now have the string version of the value stored in $value.
-        // Does it need to be encrypted?  If so encrypt it, and prefix
-        // the string with a tag so we know it's been encrypted.
-        if ($this->hasEncrypt($key)) {
-            $originalValue = $value;
-            try {
-                $value = $this->getElocryptPrefix() . Crypt::encrypt($value);
-            } catch (EncryptException $e) {
-                // Reset
-                $value = $originalValue;
-            }
-        }
-
-        $this->attributes[$key] = $value;
+        $this->encryptAttribute($key);
     }
 
     /**
-     * Decrypt an attribute if required
+     * Encrypt a stored attribute
+     *
+     * @param  string $key
+     * @return void
+     */
+    protected function encryptAttribute($key)
+    {
+        if ( ! $this->encryptable($key)) return;
+
+        try {
+            // Prefix with a string so we know it's encrypted.
+            $this->attributes[$key] = static::$ELOCRYPT_PREFIX . Crypt::encrypt(
+                $this->attributes[$key]
+            );
+
+        } catch (EncryptException $e) {}
+    }
+
+    /**
+     * Decrypt an attribute if needed
      *
      * @param string $key
      * @param mixed $value
      * @return mixed
      */
-    protected function doDecryptAttribute($key, $value)
+    protected function decryptAttribute($key, $value)
     {
-        // Does it need to be decrypted?
-        if (! $this->hasEncrypt($key)) {
-            return $value;
-        }
+        if ( ! $this->encrypted($key, $value)) return $value;
 
-        // We now have the string version of the value stored in $value.
-        // Decrypt it, removing the prefix that we added when we encrypted it.
-        $originalValue = $value;
-        $elocrypt_prefix = $this->getElocryptPrefix();
-
-        if (strpos($value, $elocrypt_prefix) !== 0) {
-            // This string has not been prefixed and so we assume that
-            // it has not been encrypted.
-            return $originalValue;
-        }
-
-        $value = substr($value, strlen($elocrypt_prefix));
         try {
-            $value = Crypt::decrypt($value);
-        } catch (DecryptException $e) {
-            // Reset
-            $value = $originalValue;
+            // Remove the prefix that we added when we encrypted it.
+            return Crypt::decrypt(
+                str_replace(static::$ELOCRYPT_PREFIX, '', $value)
+            );
         }
+        catch (DecryptException $e) {}
 
         return $value;
     }
@@ -168,10 +156,7 @@ trait Elocrypt
      */
     protected function getAttributeFromArray($key)
     {
-        // This will call the base Laravel/Eloquent function to give
-        // us the raw value taken from the attributes array.
-        $value = parent::getAttributeFromArray($key);
-        return $this->doDecryptAttribute($key, $value);
+        return $this->decryptAttribute($key, parent::getAttributeFromArray($key));
     }
 
     /**
@@ -181,11 +166,20 @@ trait Elocrypt
      */
     protected function getArrayableAttributes()
     {
-        $attributes = parent::getArrayableItems($this->attributes);
+        return $this->decryptAttributes(parent::getArrayableAttributes());
+    }
 
+    /**
+     * Map the decryption on an array of attributes
+     *
+     * @param  array $attributes
+     * @return array
+     */
+    protected function decryptAttributes($attributes)
+    {
         // Decrypt them all as required
         foreach ($attributes as $key => $value) {
-            $attributes[$key] = $this->doDecryptAttribute($key, $value);
+            $attributes[$key] = $this->decryptAttribute($key, $value);
         }
 
         return $attributes;
@@ -198,13 +192,6 @@ trait Elocrypt
      */
     public function getAttributes()
     {
-        $attributes = parent::getAttributes();
-
-        // Decrypt them all as required
-        foreach ($attributes as $key => $value) {
-            $attributes[$key] = $this->doDecryptAttribute($key, $value);
-        }
-
-        return $attributes;
+        return $this->decryptAttributes(parent::getAttributes());
     }
 }

--- a/src/Elocrypt.php
+++ b/src/Elocrypt.php
@@ -22,7 +22,7 @@ use Illuminate\Support\Facades\Crypt;
  *
  *       use Elocrypt;
  *
- *       public $encryptable = [
+ *       public $encrypts = [
  *           'first_name',
  *           'last_name',
  *           'address_line_1',
@@ -76,7 +76,7 @@ trait Elocrypt
      */
     protected function hasEncrypt($key)
     {
-        return in_array($key, $this->encryptable);
+        return in_array($key, $this->encrypts);
     }
 
     /**


### PR DESCRIPTION
To be more in line with Laravel's naming conventions, I propose you rename `$encryptable` to `$encrypts`. Reads a whole lot better and makes it more explicit that we're encrypting those fields.
