### PR TITLE
Add ability to customized prefix tag string

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This encrypts and decrypts columns stored in database tables in Laravel applicat
 transparently, by encrypting data as it is stored in the model attributes and decrypting
 data as it is recalled from the model attributes.
 
-All data that is encrypted is prefixed with a tag (currently `__ELOCRYPT__;`) so that
+All data that is encrypted is prefixed with a tag (default `__ELOCRYPT__:`) so that
 encrypted data can be easily identified.
 
 This supports columns that store either encrypted or non-encrypted data to make migration
@@ -36,10 +36,9 @@ following additions/changes:
   you can add a field to `$casts` and also to `$encrypts` so that an array can be cast to a JSON
   string first, and then encrypted.  It should also work for Lumen.
 
-* Prefix all encrypted values with a tag string (currently hard coded as `__ELOCRYPT__:` )
-  so that plain text data can be detected and handled correctly.  The task of writing a script
-  to traverse your existing database and update all plain text data to encrypted data is left
-  to the reader.
+* Prefix all encrypted values with a tag string (default `__ELOCRYPT__:` ) so that plain text
+  data can be detected and handled correctly.  The task of writing a script to traverse your
+  existing database and update all plain text data to encrypted data is left to the reader.
 
 The original Laravel 4 package is here: https://github.com/dtisgodsson/elocrypt
 
@@ -60,6 +59,31 @@ You must then run the following command:
 ```
     composer update
 ```
+
+## Configuration
+
+Publish the config file with:
+
+```
+    php artisan config::publish delatbabel/elocryptfive
+```
+
+You may then change the default prefix tag string in your `.env` config file:
+
+```
+    ELOCRYPT_PREFIX=__This_is_encrypted_data__
+```
+
+or alternatively you can change the default right in the `config/elocrypt.php` file:
+
+```php
+    return [
+
+        'prefix' => env('ELOCRYPT_PREFIX', '__This_is_encrypted_data__')
+
+    ]
+```
+
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,8 @@
         "illuminate/contracts": "^5.0",
         "illuminate/support": "^5.0",
         "illuminate/encryption": "^5.0",
+        "illuminate/container": "^5.0",
+        "illuminate/config": "^5.0",
         "paragonie/random_compat": "^1.1"
     },
     "require-dev": {

--- a/src/Elocrypt.php
+++ b/src/Elocrypt.php
@@ -7,6 +7,7 @@ namespace Delatbabel\Elocrypt;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\EncryptException;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Config;
 
 /**
  * Trait Elocrypt
@@ -60,12 +61,18 @@ use Illuminate\Support\Facades\Crypt;
  */
 trait Elocrypt
 {
-    /** @var string The prefix used to determine if a string is encrypted. */
-    protected static $ELOCRYPT_PREFIX = '__ELOCRYPT__:';
-
     //
     // Methods below here are native to the trait.
     //
+
+    /**
+     * Get the configuration setting for the prefix used to determine if a strign is encrypted
+     *
+     * @return string
+     */
+    protected function getElocryptPrefix() {
+        return Config::get('elocrypt.prefix');
+    }
 
     /**
      * Determine whether an attribute should be encrypted.
@@ -88,7 +95,7 @@ trait Elocrypt
      */
     protected function isEncrypted($value)
     {
-        return strpos((string)$value, self::$ELOCRYPT_PREFIX) === 0;
+        return strpos((string)$value, $this->getElocryptPrefix()) === 0;
     }
 
     /**
@@ -102,7 +109,7 @@ trait Elocrypt
      */
     public function encryptedAttribute($value)
     {
-        return self::$ELOCRYPT_PREFIX . Crypt::encrypt($value);
+        return $this->getElocryptPrefix() . Crypt::encrypt($value);
     }
 
     /**
@@ -116,7 +123,7 @@ trait Elocrypt
      */
     public function decryptedAttribute($value)
     {
-        return Crypt::decrypt(str_replace(self::$ELOCRYPT_PREFIX, '', $value));
+        return Crypt::decrypt(str_replace($this->getElocryptPrefix(), '', $value));
     }
 
     /**

--- a/src/Elocrypt.php
+++ b/src/Elocrypt.php
@@ -66,11 +66,12 @@ trait Elocrypt
     //
 
     /**
-     * Get the configuration setting for the prefix used to determine if a strign is encrypted
+     * Get the configuration setting for the prefix used to determine if a string is encrypted
      *
      * @return string
      */
-    protected function getElocryptPrefix() {
+    protected function getElocryptPrefix()
+    {
         return Config::get('elocrypt.prefix');
     }
 

--- a/src/Elocrypt.php
+++ b/src/Elocrypt.php
@@ -72,7 +72,7 @@ trait Elocrypt
      */
     protected function getElocryptPrefix()
     {
-        return Config::get('elocrypt.prefix');
+        return Config::has('elocrypt.prefix') ? Config::get('elocrypt.prefix') : '__ELOCRYPT__:';
     }
 
     /**

--- a/src/Elocrypt.php
+++ b/src/Elocrypt.php
@@ -6,8 +6,8 @@ namespace Delatbabel\Elocrypt;
 
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\EncryptException;
-use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Crypt;
 
 /**
  * Trait Elocrypt

--- a/src/ElocryptServiceProvider.php
+++ b/src/ElocryptServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Delatbabel\Elocrypt;
+
+use Illuminate\Support\ServiceProvider;
+
+class ElocryptServiceProvider extends ServiceProvider
+{
+
+	/**
+	 * Bootstrap the application services
+	 *
+	 * @return void
+	 */
+	public function boot()
+	{
+		$this->publishes([
+			__DIR__.'/config/config.php' => config_path('elocrypt.php')
+		]);
+	}
+
+	/**
+	 * Register the application services
+	 *
+	 * @return void
+	 */
+	public function register()
+	{
+
+	}
+}

--- a/src/ElocryptServiceProvider.php
+++ b/src/ElocryptServiceProvider.php
@@ -7,25 +7,25 @@ use Illuminate\Support\ServiceProvider;
 class ElocryptServiceProvider extends ServiceProvider
 {
 
-	/**
-	 * Bootstrap the application services
-	 *
-	 * @return void
-	 */
-	public function boot()
-	{
-		$this->publishes([
-			__DIR__.'/config/config.php' => config_path('elocrypt.php')
-		]);
-	}
+		/**
+	 	* Bootstrap the application services
+	 	*
+	 	* @return void
+	 	*/
+		public function boot()
+		{
+				$this->publishes([
+						__DIR__.'/config/config.php' => config_path('elocrypt.php')
+				]);
+		}
 
-	/**
-	 * Register the application services
-	 *
-	 * @return void
-	 */
-	public function register()
-	{
-
-	}
+		/**
+		 * Register the application services
+		 *
+		 * @return void
+		 */
+		public function register()
+		{
+			//
+		}
 }

--- a/src/ElocryptServiceProvider.php
+++ b/src/ElocryptServiceProvider.php
@@ -8,10 +8,10 @@ class ElocryptServiceProvider extends ServiceProvider
 {
 
 		/**
-	 	* Bootstrap the application services
-	 	*
-	 	* @return void
-	 	*/
+	   * Bootstrap the application services
+	   *
+	 	 * @return void
+	 	 */
 		public function boot()
 		{
 				$this->publishes([

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+	'prefix' => env('ELOCRYPT_PREFIX', '__ELOCRYPT__:')
+
+];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -2,6 +2,6 @@
 
 return [
 
-	'prefix' => env('ELOCRYPT_PREFIX', '__ELOCRYPT__:')
+		'prefix' => env('ELOCRYPT_PREFIX', '__ELOCRYPT__:')
 
 ];

--- a/tests/DummyModel.php
+++ b/tests/DummyModel.php
@@ -6,6 +6,8 @@
  */
 
 use Illuminate\Encryption\Encrypter;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
 
 /**
  * Class DummyModel
@@ -25,6 +27,13 @@ class DummyModel extends BaseModel
     public function __construct(array $attributes)
     {
         $this->encrypter = new Encrypter('088409730f085dd15e8e3a7d429dd185', 'AES-256-CBC');
+
+        $app = new Container();
+        $app->singleton('app', 'Illuminate\Container\Container');
+        $app->singleton('config', 'Illuminate\Config\Repository');
+        $app['config']->set('elocrypt.prefix', '__ELOCRYPT__:');
+        Facade::setFacadeApplication($app);
+
         parent::__construct($attributes);
     }
 
@@ -39,7 +48,7 @@ class DummyModel extends BaseModel
      */
     public function encryptedAttribute($value)
     {
-        return self::$ELOCRYPT_PREFIX . $this->encrypter->encrypt($value);
+        return $this->getElocryptPrefix() . $this->encrypter->encrypt($value);
     }
 
     /**
@@ -53,6 +62,6 @@ class DummyModel extends BaseModel
      */
     public function decryptedAttribute($value)
     {
-        return $this->encrypter->decrypt(str_replace(self::$ELOCRYPT_PREFIX, '', $value));
+        return $this->encrypter->decrypt(str_replace($this->getElocryptPrefix(), '', $value));
     }
 }


### PR DESCRIPTION
This change introduces the ability to customize the prefix string via the `.env` file or the published `config/elocrypt.php` file.

Tests have been modified to create an app container and set the config value so it can be loaded in the model.
