### PR TITLE
add $keys to the getAttributes() call to comply with laravel 5.3.17

### DIFF
--- a/src/Elocrypt.php
+++ b/src/Elocrypt.php
@@ -229,10 +229,12 @@ trait Elocrypt
     /**
      * Get all of the current attributes on the model.
      *
+     * @param array $keys
+     *
      * @return array
      */
-    public function getAttributes()
+    public function getAttributes($keys = [])
     {
-        return $this->doDecryptAttributes(parent::getAttributes());
+        return $this->doDecryptAttributes(parent::getAttributes($keys));
     }
 }


### PR DESCRIPTION
Otherwise you get this message

`ErrorException: Declaration of Delatbabel\Elocrypt\Elocrypt::getAttributes() should be compatible with Illuminate\Database\Eloquent\Model::getAttributes($keys = Array)`
